### PR TITLE
Replace stop button macro with direct call to action_emergency_stop

### DIFF
--- a/V1/config/skirt_button_pcb.cfg
+++ b/V1/config/skirt_button_pcb.cfg
@@ -58,13 +58,6 @@ timeout: 1800
 # Please refer to https://www.klipper3d.org/Config_Reference.html?h=macro#g-code-macros-and-events
 #
 
-[gcode_macro _BUTTON_B1]
-# EMERGENCY STOP
-gcode:
-  _status_button_busy BUTTON=1
-  M112
-  _status_button_ready BUTTON=1
-
 [gcode_macro _BUTTON_B2]
 # Go to service position
 gcode:
@@ -301,9 +294,14 @@ initial_GREEN: 0.0
 initial_BLUE: 0.1
 
 # Settings for the Buttons
+
+# Emergency Stop
+# The stop button is implemented without a macro, because when using a macro, or the M112 g-code command
+# the stop won't be processed until all other commands already in the queue are processed. This often
+# means the stop occurs too late. 
 [gcode_button b1]
 pin: ^!skirt: PB11
-press_gcode: _BUTTON_B1
+press_gcode: {action_emergency_stop()} 
 
 [gcode_button b2]
 pin: ^!skirt: PB10


### PR DESCRIPTION
Replace stop button macro with direct call to action_emergency_stop. This is necessary to ensure that the emergency stop is processed immediately, and not after any commands already in the queue.
